### PR TITLE
Last try of fixing glibc

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -18,7 +18,7 @@ on:
         type: string
 jobs:
   run_integration_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: mysql:latest

--- a/tools/ci/install_rust_g.sh
+++ b/tools/ci/install_rust_g.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 source dependencies.sh
 
+sudo dpkg --add-architecture i386 
+
+sudo apt-get update || true
+sudo apt-get install libgcc-s1:i386 g++-multilib zlib1g-dev:i386 libssl-dev:i386
+
 mkdir -p ~/.byond/bin
 wget -nv -O ~/.byond/bin/librust_g.so "https://github.com/tgstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
 chmod +x ~/.byond/bin/librust_g.so


### PR DESCRIPTION
OpenSSL 1.1 is now removed, no idea why they've been keeping it there, better ask